### PR TITLE
Use groovy-eclipse-compiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,20 @@
 REST API extension with SQL dataSource
 ======================================
 
+IDE SETUP
+---------
+
+## Eclipse Mars (4.5)
+
+- Go in Help > Install New Software...
+- Work with `org.codehaus.groovy.eclipse.site - http://dist.springsource.org/snapshot/GRECLIPSE/e4.5`
+- Select following features to install:
+	- Extra compiler 1.8 
+	- Groovy eclipse
+	- m2e configurator 
+- Install and restart Eclipse
+- Go to Help > Eclipse Marketplace...
+- Search for Spock Plugin and install it
 
 API EXTENSION SETUP
 --------------------

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.bonitasoft.example</groupId>
     <artifactId>rest-api-sql-datasource</artifactId>
@@ -7,7 +6,7 @@
     <packaging>jar</packaging>
     <properties>
         <bonita.version>7.0.1</bonita.version>
-        <groovy.version>1.8.6</groovy.version>
+        <groovy.version>1.8.6-01</groovy.version>
     </properties>
     <repositories>
         <repository>
@@ -22,12 +21,6 @@
             <artifactId>servlet-api</artifactId>
             <version>2.5</version>
             <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.codehaus.groovy</groupId>
-            <artifactId>groovy-all</artifactId>
-            <version>${groovy.version}</version>
-            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.bonitasoft.engine</groupId>
@@ -83,35 +76,23 @@
 
         <plugins>
             <plugin>
-                <groupId>org.codehaus.gmaven</groupId>
-                <artifactId>gmaven-plugin</artifactId>
-                <version>1.3</version>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.3</version>
                 <configuration>
-                    <providerSelection>1.7</providerSelection>
+                    <source>1.7</source>
+                    <target>1.7</target>
+                    <compilerId>groovy-eclipse-compiler</compilerId>
                 </configuration>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>compile</goal>
-                            <goal>testCompile</goal>
-                        </goals>
-                    </execution>
-                </executions>
                 <dependencies>
                     <dependency>
-                        <groupId>org.codehaus.gmaven.runtime</groupId>
-                        <artifactId>gmaven-runtime-1.7</artifactId>
-                        <version>1.3</version>
-                        <exclusions>
-                            <exclusion>
-                                <groupId>org.codehaus.groovy</groupId>
-                                <artifactId>groovy-all</artifactId>
-                            </exclusion>
-                        </exclusions>
+                        <groupId>org.codehaus.groovy</groupId>
+                        <artifactId>groovy-eclipse-compiler</artifactId>
+                        <version>2.9.2-01</version>
                     </dependency>
                     <dependency>
                         <groupId>org.codehaus.groovy</groupId>
-                        <artifactId>groovy-all</artifactId>
+                        <artifactId>groovy-eclipse-batch</artifactId>
                         <version>${groovy.version}</version>
                     </dependency>
                 </dependencies>


### PR DESCRIPTION
- Use groovy-eclipse-compiler instead of gcompiler to be compliant with eclipse maven tooling.
- Improve README to setup Eclipse environment
